### PR TITLE
Add root config & custom port docker-compose setup

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+model_list:
+  - model_name: gpt-3.5-turbo
+    litellm_params:
+      model: gpt-3.5-turbo
+
+litellm_settings:
+  callbacks: ["prometheus"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,15 @@ services:
         target: runtime
     image: ghcr.io/berriai/litellm:main-stable
     #########################################
-    ## Uncomment these lines to start proxy with a config.yaml file ##
-    # volumes:
-    #  - ./config.yaml:/app/config.yaml <<- this is missing in the docker-compose file currently
-    # command:
-    #  - "--config=/app/config.yaml"
+    ## Start proxy with config.yaml and custom port ##
+    volumes:
+      - ./config.yaml:/app/config.yaml
+    command:
+      - "--config=/app/config.yaml"
+      - "--port=4001"
     ##############################################
     ports:
-      - "4001:4000" # Map the container port to the host, change the host port if necessary
+      - "4001:4001" # Map the container port to the host
     environment:
       DATABASE_URL: "postgresql://llmproxy:dbpassword9090@db:5432/litellm"
       STORE_MODEL_IN_DB: "True" # allows adding models to proxy via UI

--- a/docs/my-website/docs/proxy/prometheus.md
+++ b/docs/my-website/docs/proxy/prometheus.md
@@ -50,7 +50,16 @@ curl --location 'http://0.0.0.0:4000/chat/completions' \
 }'
 ```
 
-View Metrics on `/metrics`, Visit `http://localhost:4000/metrics` 
+View Metrics on `/metrics`.
+
+The metrics endpoint listens on the same port as the LiteLLM proxy. If you change
+the server port using `--port` or the `PORT` environment variable, query
+`/metrics` on that port. For example:
+```shell
+litellm --config config.yaml --port 8080
+# Metrics now available at http://localhost:8080/metrics
+```
+
 ```shell
 http://localhost:4000/metrics
 

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -4,4 +4,4 @@ global:
 scrape_configs:
   - job_name: 'litellm'
     static_configs:
-      - targets: ['litellm:4000']  # Assuming Litellm exposes metrics at port 4000
+      - targets: ['litellm:4001']  # Change the port if the proxy runs on a different port


### PR DESCRIPTION
## Summary
- add a simple `config.yaml` in the repo root enabling Prometheus
- mount the config in `docker-compose.yml` and run LiteLLM on port 4001
- update Prometheus scrape config to point at the new port

## Testing
- `pre-commit run --files docker-compose.yml prometheus.yml config.yaml` *(fails: command not found)*
- `pytest` *(fails: command not found)*
